### PR TITLE
Bugfix / Grab sequence id directly from params

### DIFF
--- a/lib/mini_stitch/api.rb
+++ b/lib/mini_stitch/api.rb
@@ -8,7 +8,7 @@ module MiniStitch
 
       @request_params = { Authorization: "Bearer #{MiniStitch.configuration.token}" }.merge(DEFAULT_REQUEST_PARAMS)
       @table_name = table_name
-      @sequence = sequence.to_sym
+      @sequence = sequence.to_i
       @key_names = key_names.map(&:to_s)
       @data = build_records(data)
     end
@@ -28,7 +28,7 @@ module MiniStitch
         {
           client_id: MiniStitch.configuration.client_id,
           table_name: table_name,
-          sequence: record[sequence].to_i,
+          sequence: sequence,
           action: default_api_action,
           key_names: key_names,
           data: record


### PR DESCRIPTION
Fixes the issue where sequence was being incorrectly grabbed off of a data record directly, essentially resulting in a call to `nil.to_i` which resulted in `0` being passed in as the `sdc_sequence` for all records sent to Stitch.

As a result, updated records were being discarded by Stitch before landing in Redshift.