### PR TITLE
be more paranoid of external libraries

### DIFF
--- a/lib/mini_stitch/api.rb
+++ b/lib/mini_stitch/api.rb
@@ -53,7 +53,8 @@ module MiniStitch
     def stitch_post_request(url)
       JSON.parse(RestClient.post(url, @data.to_json, @request_params))
     rescue RestClient::ExceptionWithResponse => e
-      { 'status' => e.message, 'message' => JSON.parse(e.response)['errors'] }
+      # timeouts have nil responses
+      { 'status' => e.message, 'message' => e.response.nil? ? 'request timed out' : JSON.parse(e.response)['errors'] }
     end
   end
 end

--- a/mini_stitch.gemspec
+++ b/mini_stitch.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'json', '>= 1.8', '<2.0'
   spec.add_dependency 'oj', '~> 3.3', '>= 3.3.9'
-  spec.add_dependency 'rest-client', '~> 2.0', '>= 2.0.2'
+  spec.add_dependency 'rest-client', '~> 2.0', '=2.0.2' # TODO locking until testing impact in anyroad of newer versions
 end


### PR DESCRIPTION
Protects against this issue:  https://github.com/rest-client/rest-client/issues/766

Basically, timeouts were failing on creating the message response with JSON.parse in the rescue block.